### PR TITLE
Require proptypes

### DIFF
--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,10 +1,10 @@
 import { string, shape, object } from "prop-types";
 
 export const documentPropType = shape({
-  id: string,
-  documentCollectionId: string,
-  name: string,
-  documentFile: string,
-  dateCreated: string,
-  attributes: object
+  id: string.isRequired,
+  documentCollectionId: string.isRequired,
+  name: string.isRequired,
+  documentFile: string.isRequired,
+  dateCreated: string.isRequired,
+  attributes: object.isRequired
 });


### PR DESCRIPTION
I assume all these properties should always exist. By declaring required, you'll get a helpful propType warning if they're missing.