### PR TITLE
Eliminate needless context

### DIFF
--- a/src/components/DocumentViewer/DocumentViewer.js
+++ b/src/components/DocumentViewer/DocumentViewer.js
@@ -1,19 +1,17 @@
 import React from "react";
 import PDFViewer from "./PDFViewer";
-import { DocumentViewerContext } from "./DocumentViewerContext";
 import { documentPropType } from "../../propTypes";
 import "./DocumentViewer.scss";
 
-export default function DocumentViewer(props) {
-  let pdfDocument = props.document;
-  let documentFile = pdfDocument ? pdfDocument.documentFile : null;
+export default function DocumentViewer({ document }) {
+  const file = document ? document.documentFile : null;
 
   return (
     <section
       aria-label="Document viewer container"
       className="document-viewer-container"
     >
-      {!pdfDocument || !pdfDocument.documentFile ? (
+      {!document || !document.documentFile ? (
         <span
           aria-label="Document viewer with no document"
           className="document-viewer-empty"
@@ -21,13 +19,7 @@ export default function DocumentViewer(props) {
           No document selected
         </span>
       ) : (
-        <DocumentViewerContext.Provider
-          value={{
-            documentFile
-          }}
-        >
-          <PDFViewer />
-        </DocumentViewerContext.Provider>
+        <PDFViewer file={file} />
       )}
     </section>
   );

--- a/src/components/DocumentViewer/DocumentViewer.js
+++ b/src/components/DocumentViewer/DocumentViewer.js
@@ -4,7 +4,7 @@ import { documentPropType } from "../../propTypes";
 import "./DocumentViewer.scss";
 
 export default function DocumentViewer({ document }) {
-  const file = document ? document.documentFile : null;
+  const base64String = document ? document.documentFile : null;
 
   return (
     <section
@@ -19,7 +19,7 @@ export default function DocumentViewer({ document }) {
           No document selected
         </span>
       ) : (
-        <PDFViewer file={file} />
+        <PDFViewer base64String={base64String} />
       )}
     </section>
   );

--- a/src/components/DocumentViewer/DocumentViewerContext.js
+++ b/src/components/DocumentViewer/DocumentViewerContext.js
@@ -1,3 +1,0 @@
-import { createContext } from "react";
-
-export const DocumentViewerContext = createContext({});

--- a/src/components/DocumentViewer/PDFViewer.js
+++ b/src/components/DocumentViewer/PDFViewer.js
@@ -1,21 +1,20 @@
-import React, { useContext, useEffect, useRef, useState } from "react";
-import { DocumentViewerContext } from "./DocumentViewerContext";
+import React, { useEffect, useRef, useState } from "react";
 import { decodeBase64 } from "../../util/base64Utilities";
+import PropTypes from "prop-types";
 
-export default function PDFViewer() {
+export default function PDFViewer({ file }) {
   let iFrameRef = useRef();
   const [isFrameLoaded, setIsFrameLoaded] = useState(false);
-  const { documentFile } = useContext(DocumentViewerContext);
 
   useEffect(() => {
     if (!isFrameLoaded) {
       return;
     }
 
-    var pdf = decodeBase64(documentFile);
+    var pdf = decodeBase64(file);
 
     iFrameRef.current.contentWindow.PDFViewerApplication.open(pdf);
-  }, [isFrameLoaded, documentFile]);
+  }, [isFrameLoaded, file]);
 
   return (
     <iframe
@@ -31,3 +30,8 @@ export default function PDFViewer() {
     />
   );
 }
+
+PDFViewer.propTypes = {
+  /** Base64 encoded string */
+  file: PropTypes.string.isRequired
+};

--- a/src/components/DocumentViewer/PDFViewer.js
+++ b/src/components/DocumentViewer/PDFViewer.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { decodeBase64 } from "../../util/base64Utilities";
 import PropTypes from "prop-types";
 
-export default function PDFViewer({ file }) {
+export default function PDFViewer({ base64String }) {
   let iFrameRef = useRef();
   const [isFrameLoaded, setIsFrameLoaded] = useState(false);
 
@@ -11,10 +11,10 @@ export default function PDFViewer({ file }) {
       return;
     }
 
-    var pdf = decodeBase64(file);
+    var pdf = decodeBase64(base64String);
 
     iFrameRef.current.contentWindow.PDFViewerApplication.open(pdf);
-  }, [isFrameLoaded, file]);
+  }, [isFrameLoaded, base64String]);
 
   return (
     <iframe
@@ -32,6 +32,5 @@ export default function PDFViewer({ file }) {
 }
 
 PDFViewer.propTypes = {
-  /** Base64 encoded string */
-  file: PropTypes.string.isRequired
+  base64String: PropTypes.string.isRequired
 };


### PR DESCRIPTION
Context is useful for large apps when data is used by nearly every component (themes, logged in user data, a11n, etc). This usage appears to be merely in lieu of passing props to a direct child. Context adds complexity and needless overhead in this case.